### PR TITLE
Fix quote boxes

### DIFF
--- a/book.json
+++ b/book.json
@@ -11,7 +11,7 @@
     "plugins": [
         "heading-anchors@1.0.3",
         "ga@1.0.1",
-        "richquotes@0.0.7",
+        "callouts",
         "github@2.0.0",
         "language-picker",
         "sidebar-ad",

--- a/en/README.md
+++ b/en/README.md
@@ -1,6 +1,8 @@
 # Django Girls Tutorial
 [![Gitter](https://badges.gitter.im/DjangoGirls/tutorial.svg)](https://gitter.im/DjangoGirls/tutorial)
 
+> #### Info
+> 
 > This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
 > To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
 
@@ -22,6 +24,8 @@ It will (more or less) look like this:
 
 ![Figure 0.1](images/application.png)
 
+> #### Hint
+> 
 > If you work with the tutorial on your own and don't have a coach who will help you in case of any problem, we have a chat system for you: [![Gitter](https://badges.gitter.im/DjangoGirls/tutorial.svg)](https://gitter.im/DjangoGirls/tutorial). We asked our coaches and previous attendees to be there from time to time and help others with the tutorial! Don't be afraid to ask your question there!
 
 OK, [let's start at the beginning…](./how_the_internet_works/README.md)

--- a/en/chromebook_setup/README.md
+++ b/en/chromebook_setup/README.md
@@ -1,5 +1,7 @@
 # Chromebook setup
 
-> **Note** If you already worked through the Installation steps, no need to do this again – you can skip straight ahead to [Introduction to Python](../python_introduction/README.md).
+> #### Note
+> 
+> If you already worked through the Installation steps, no need to do this again – you can skip straight ahead to [Introduction to Python](../python_introduction/README.md).
 
 {% include "/chromebook_setup/instructions.md" %}

--- a/en/code_editor/README.md
+++ b/en/code_editor/README.md
@@ -1,11 +1,21 @@
 # Code editor
 
-> For readers at home: this chapter is covered in the [Installing Python & Code Editor](https://www.youtube.com/watch?v=pVTaqzKZCdA&t=4m43s) video.
+> #### Info::For readers at home
+> 
+> this chapter is covered in the [Installing Python & Code Editor](https://www.youtube.com/watch?v=pVTaqzKZCdA&t=4m43s) video.
 
 You're about to write your first line of code, so it's time to download a code editor!
 
-> **Note** If you're using a Chromebook, skip this chapter and make sure you follow the [Chromebook Setup](../chromebook_setup/README.md) instructions.
+> #### Note
+> 
+> If you're using a Chromebook, skip this chapter and make sure you follow the [Chromebook Setup](../chromebook_setup/README.md) instructions.
 
-> **Note** You might have done this earlier in the Installation chapter – if so, you can skip right ahead to the next chapter!
+&nbsp;
+
+> #### Note
+> 
+> You might have done this earlier in the Installation chapter – if so, you can skip right ahead to the next chapter!
+
+&nbsp;
 
 {% include "/code_editor/instructions.md" %}

--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -1,6 +1,8 @@
 # Deploy!
 
-> **Note** The following chapter can be sometimes a bit hard to get through. Persist and finish it; deployment is an important part of the website development process. This chapter is placed in the middle of the tutorial so that your mentor can help with the slightly trickier process of getting your website online. This means you can still finish the tutorial on your own if you run out of time.
+> #### Note
+> 
+> The following chapter can be sometimes a bit hard to get through. Persist and finish it; deployment is an important part of the website development process. This chapter is placed in the middle of the tutorial so that your mentor can help with the slightly trickier process of getting your website online. This means you can still finish the tutorial on your own if you run out of time.
 
 Until now, your website was only available on your computer.  Now you will learn how to deploy it! Deploying is the process of publishing your application on the Internet so people can finally go and see your app. :)
 
@@ -12,7 +14,9 @@ These three places will be important to you.  Your local computer will be the pl
 
 # Git
 
-> **Note** If you already did the Installation steps, there's no need to do this again – you can skip to the next section and start creating your Git repository.
+> #### Note
+> 
+> If you already did the Installation steps, there's no need to do this again – you can skip to the next section and start creating your Git repository.
 
 {% include "/deploy/install_git.md" %}
 
@@ -20,7 +24,9 @@ These three places will be important to you.  Your local computer will be the pl
 
 Git tracks changes to a particular set of files in what's called a code repository (or "repo" for short). Let's start one for our project. Open up your console and run these commands, in the `djangogirls` directory:
 
-> **Note** Check your current working directory with a `pwd` (Mac OS X/Linux) or `cd` (Windows) command before initializing the repository. You should be in the `djangogirls` folder.
+> #### Note 
+> 
+> Check your current working directory with a `pwd` (Mac OS X/Linux) or `cd` (Windows) command before initializing the repository. You should be in the `djangogirls` folder.
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -47,9 +53,15 @@ db.sqlite3
 
 And save it as `.gitignore` in the "djangogirls" folder.
 
-> **Note** The dot at the beginning of the file name is important!  If you're having any difficulty creating it (Macs don't like you to create files that begin with a dot via the Finder, for example), then use the "Save As" feature in your editor; it's bulletproof.
+> #### Note
+> 
+> The dot at the beginning of the file name is important!  If you're having any difficulty creating it (Macs don't like you to create files that begin with a dot via the Finder, for example), then use the "Save As" feature in your editor; it's bulletproof.
 
-> **Note** One of the files you specified in your `.gitignore` file is `db.sqlite3`. That file is your local database, where all or your posts are stored. We don't want to add this to your repository because your website on PythonAnywhere is going to be using a different database.  That database could be SQLite, like your development machine, but usually you will use one called MySQL which can deal with a lot more site visitors than SQLite. Either way, by ignoring your SQLite database for the GitHub copy, it means that all of the posts you created so far are going to stay and only be available locally, but you're going to have to add them again on production. You should think of your local database as a good playground where you can test different things and not be afraid that you're going to delete your real posts from your blog.
+&nbsp;
+
+> #### Note
+> 
+> One of the files you specified in your `.gitignore` file is `db.sqlite3`. That file is your local database, where all or your posts are stored. We don't want to add this to your repository because your website on PythonAnywhere is going to be using a different database.  That database could be SQLite, like your development machine, but usually you will use one called MySQL which can deal with a lot more site visitors than SQLite. Either way, by ignoring your SQLite database for the GitHub copy, it means that all of the posts you created so far are going to stay and only be available locally, but you're going to have to add them again on production. You should think of your local database as a good playground where you can test different things and not be afraid that you're going to delete your real posts from your blog.
 
 It's a good idea to use a `git status` command before `git add` or whenever you find yourself unsure of what has changed. This will help prevent any surprises from happening, such as wrong files being added or committed. The `git status` command returns information about any untracked/modified/staged files, the branch status, and much more. The output should be similar to the following:
 
@@ -93,7 +105,9 @@ Then, create a new repository, giving it the name "my-first-blog". Leave the "in
 
 <img src="images/new_github_repo.png" />
 
-> **Note** The name `my-first-blog` is important – you could choose something else, but it's going to occur lots of times in the instructions below, and you'd have to substitute it each time. It's probably easier to just stick with the name `my-first-blog`.
+> #### Note
+> 
+> The name `my-first-blog` is important – you could choose something else, but it's going to occur lots of times in the instructions below, and you'd have to substitute it each time. It's probably easier to just stick with the name `my-first-blog`.
 
 On the next screen, you'll be shown your repo's clone URL. Choose the "HTTPS" version, copy it, and we'll paste it into the terminal shortly:
 
@@ -130,7 +144,9 @@ Your code is now on GitHub. Go and check it out!  You'll find it's in fine compa
 
 # Setting up our blog on PythonAnywhere
 
-> **Note** You might have already created a PythonAnywhere account earlier during the install steps – if so, no need to do it again.
+> #### Note
+> 
+> You might have already created a PythonAnywhere account earlier during the install steps – if so, no need to do it again.
 
 {% include "/deploy/signup_pythonanywhere.md" %}
 
@@ -139,7 +155,9 @@ Your code is now on GitHub. Go and check it out!  You'll find it's in fine compa
 
 When you've signed up for PythonAnywhere, you'll be taken to your dashboard or "Consoles" page. Choose the option to start a "Bash" console – that's the PythonAnywhere version of a console, just like the one on your computer.
 
-> **Note** PythonAnywhere is based on Linux, so if you're on Windows, the console will look a little different from the one on your computer.
+> #### Note
+> 
+> PythonAnywhere is based on Linux, so if you're on Windows, the console will look a little different from the one on your computer.
 
 Let's pull down our code from GitHub and onto PythonAnywhere by creating a "clone" of our repo. Type the following into the console on PythonAnywhere (don't forget to use your GitHub username in place of `<your-github-username>`):
 
@@ -194,7 +212,9 @@ Successfully installed django-1.10.4
 ```
 
 
-> **Note** The `pip install` step can take a couple of minutes.  Patience, patience!  But if it takes more than five minutes, something is wrong.  Ask your coach.
+> #### Note
+> 
+> The `pip install` step can take a couple of minutes.  Patience, patience!  But if it takes more than five minutes, something is wrong.  Ask your coach.
 
 <!--TODO: think about using requirements.txt instead of pip install.-->
 
@@ -221,7 +241,9 @@ Click back to the PythonAnywhere dashboard by clicking on its logo, and then cli
 
 After confirming your domain name, choose **manual configuration** (N.B. – *not* the "Django" option) in the dialog. Next choose **Python 3.5**, and click Next to finish the wizard.
 
-> **Note** Make sure you choose the "Manual configuration" option, not the "Django" one. We're too cool for the default PythonAnywhere Django setup. ;-)
+> #### Note
+> 
+> Make sure you choose the "Manual configuration" option, not the "Django" one. We're too cool for the default PythonAnywhere Django setup. ;-)
 
 
 ### Setting the virtualenv
@@ -232,7 +254,9 @@ You'll be taken to the PythonAnywhere config screen for your webapp, which is wh
 
 In the "Virtualenv" section, click the red text that says "Enter the path to a virtualenv", and enter `/home/<your-PythonAnywhere-username>/my-first-blog/myvenv/`. Click the blue box with the checkmark to save the path before moving on.
 
-> **Note** Substitute your own PythonAnywhere username as appropriate. If you make a mistake, PythonAnywhere will show you a little warning.
+> #### Note
+> 
+> Substitute your own PythonAnywhere username as appropriate. If you make a mistake, PythonAnywhere will show you a little warning.
 
 
 ### Configuring the WSGI file
@@ -259,8 +283,15 @@ from django.contrib.staticfiles.handlers import StaticFilesHandler
 application = StaticFilesHandler(get_wsgi_application())
 ```
 
-> **Note** Don't forget to substitute in your own PythonAnywhere username where it says `<your-PythonAnywhere-username>`.
-> **Note** In line four, we make sure Python anywhere knows how to find our application. It is very important that this path name is correct, and especially that there are no extra spaces here. Otherwise you will see an "ImportError" in the error log.
+> #### Note
+> 
+> Don't forget to substitute in your own PythonAnywhere username where it says `<your-PythonAnywhere-username>`.
+
+&nbsp;
+
+> #### Note
+> 
+> In line four, we make sure Python anywhere knows how to find our application. It is very important that this path name is correct, and especially that there are no extra spaces here. Otherwise you will see an "ImportError" in the error log.
 
 This file's job is to tell PythonAnywhere where our web app lives and what the Django settings file's name is.
 

--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -14,7 +14,9 @@ data-collapse=true ces-->
 
 Download Git from [git-scm.com](https://git-scm.com/) and just follow the instructions.
 
-> **Note** If you are running OS X 10.6, 10.7, or 10.8, you will need to install the version of git from here: [Git installer for OS X Snow Leopard](https://sourceforge.net/projects/git-osx-installer/files/git-2.3.5-intel-universal-snow-leopard.dmg/download)
+> #### Note
+> 
+> If you are running OS X 10.6, 10.7, or 10.8, you will need to install the version of git from here: [Git installer for OS X Snow Leopard](https://sourceforge.net/projects/git-osx-installer/files/git-2.3.5-intel-universal-snow-leopard.dmg/download)
 
 <!--endsec-->
 

--- a/en/deploy/signup_pythonanywhere.md
+++ b/en/deploy/signup_pythonanywhere.md
@@ -4,4 +4,6 @@ Next it's time to sign up for a free "Beginner" account on PythonAnywhere.
 * [www.pythonanywhere.com](https://www.pythonanywhere.com/)
 
 
-> **Note** When choosing your username here, bear in mind that your blog's URL will take the form `yourusername.pythonanywhere.com`, so choose either your own nickname, or a name for what your blog is all about.
+> #### Note
+> 
+> When choosing your username here, bear in mind that your blog's URL will take the form `yourusername.pythonanywhere.com`, so choose either your own nickname, or a name for what your blog is all about.

--- a/en/django_admin/README.md
+++ b/en/django_admin/README.md
@@ -20,6 +20,8 @@ OK, time to look at our Post model. Remember to run `python manage.py runserver`
 
 To log in, you need to create a *superuser* - a user account that has control over everything on the site. Go back to the command line, type `python manage.py createsuperuser`, and press enter.
 
+> #### Note
+> 
 > Remember, to write new commands while the web server is running, open a new terminal window and activate your virtualenv. We reviewed how to write new commands in the <b>Your first Django project!</b> chapter, in the <b>Starting the web server</b> section.
 
 When prompted, type your username (lowercase, no spaces), email address, and password. Don't worry that you can't see the password you're typing in – that's how it's supposed to be. Just type it in and press `enter` to continue. The output should look like this (where the username and email should be your own ones):

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -251,6 +251,8 @@ You might have noticed that we are setting the publish date before saving the po
 
 That is awesome!
 
+> #### Info
+> 
 > As we have recently used the Django admin interface, the system currently thinks we are still logged in. There are a few situations that could lead to us being logged out (closing the browser, restarting the DB, etc.). If, when creating a post, you find that you are getting errors referring to the lack of a logged-in user, head to the admin page http://127.0.0.1:8000/admin and log in again. This will fix the issue temporarily. There is a permanent fix awaiting you in the __Homework: add security to your website!__ chapter after the main tutorial.
 
 ![Logged in error](images/post_create_error.png)

--- a/en/django_installation/README.md
+++ b/en/django_installation/README.md
@@ -1,7 +1,15 @@
 # Django installation
 
-> **Note** If you're using a Chromebook, skip this chapter and make sure you follow the [Chromebook Setup](../chromebook_setup/README.md) instructions.
+> #### Note
+> 
+> If you're using a Chromebook, skip this chapter and make sure you follow the [Chromebook Setup](../chromebook_setup/README.md) instructions.
 
-> **Note** If you already worked through the Installation steps then you've already done this – you can go straight to the next chapter!
+&nbsp;
+
+> #### Note
+> 
+> If you already worked through the Installation steps then you've already done this – you can go straight to the next chapter!
+
+&nbsp;
 
 {% include "/django_installation/instructions.md" %}

--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -1,5 +1,7 @@
+> #### Info
+> 
 > Part of this section is based on tutorials by Geek Girls Carrots (https://github.com/ggcarrots/django-carrots).
-
+> 
 > Part of this section is based on the [django-marcador
 tutorial](http://django-marcador.keimlink.de/) licensed under the Creative Commons
 Attribution-ShareAlike 4.0 International License. The django-marcador tutorial
@@ -14,7 +16,9 @@ So, let's create a **virtual environment** (also called a *virtualenv*). Virtual
 
 All you need to do is find a directory in which you want to create the `virtualenv`; your home directory, for example. On Windows it might look like `C:\Users\Name\` (where `Name` is the name of your login).
 
-> __NOTE:__ On Windows, make sure that this directory does not contain accented or special characters; if your username contains accented characters, use a different directory, for example `C:\djangogirls`.
+> #### NOTE
+> 
+> On Windows, make sure that this directory does not contain accented or special characters; if your username contains accented characters, use a different directory, for example `C:\djangogirls`.
 
 For this tutorial we will be using a new directory `djangogirls` from your home directory:
 
@@ -58,8 +62,10 @@ $ python3 -m venv myvenv
 
 `myvenv` is the name of your `virtualenv`. You can use any other name, but stick to lowercase and use no spaces. It is also good idea to keep the name short as you'll be referencing it a lot!
 
-> __NOTE:__ On some versions of Debian/Ubuntu you may receive the following error:
-
+> #### Note
+> 
+> On some versions of Debian/Ubuntu you may receive the following error:
+> 
 >{% filename %}command-line{% endfilename %}
 >```
 >The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
@@ -73,34 +79,42 @@ $ python3 -m venv myvenv
 >$ sudo apt-get install python3-venv
 >```
 
-> __NOTE:__ On some versions of Debian/Ubuntu initiating the virtual environment like this currently gives the following error:
+&nbsp;
 
+> #### Note
+> 
+> On some versions of Debian/Ubuntu initiating the virtual environment like this currently gives the following error:
+> 
 >{% filename %}command-line{% endfilename %}
 >```
 >Error: Command '['/home/eddie/Slask/tmp/venv/bin/python3', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1
 >```
-
+> 
 > To get around this, use the `virtualenv` command instead.
-
+> 
 >{% filename %}command-line{% endfilename %}
 >```
 >$ sudo apt-get install python-virtualenv
 >$ virtualenv --python=python3.5 myvenv
 >```
 
-> __NOTE:__ If you get an error like
+&nbsp;
 
->{% filename %}command-line{% endfilename %}
->```
->E: Unable to locate package python3-venv
->```
-
+> #### Note
+> 
+> If you get an error like
+> 
+> {% filename %}command-line{% endfilename %}
+> ```
+> E: Unable to locate package python3-venv
+> ```
+> 
 > then instead run:
 >
->{% filename %}command-line{% endfilename %}
->```
->sudo apt install python3.5-venv
->```
+> {% filename %}command-line{% endfilename %}
+> ```
+> sudo apt install python3.5-venv
+> ```
 
 <!--endsec-->
 
@@ -118,7 +132,9 @@ Start your virtual environment by running:
 C:\Users\Name\djangogirls> myvenv\Scripts\activate
 ```
 
-> __NOTE:__ on Windows 10 you might get an error in the Windows PowerShell that says `execution of scripts is disabled on this system`. In this case, open another Windows PowerShell with the "Run as Administrator" option.  Then try typing the following command before starting your virtual environment:
+> #### Note
+> 
+> on Windows 10 you might get an error in the Windows PowerShell that says `execution of scripts is disabled on this system`. In this case, open another Windows PowerShell with the "Run as Administrator" option.  Then try typing the following command before starting your virtual environment:
 >
 >{% filename %}command-line{% endfilename %}
 >```
@@ -141,7 +157,9 @@ $ source myvenv/bin/activate
 
 Remember to replace `myvenv` with your chosen `virtualenv` name!
 
-> __NOTE:__ sometimes `source` might not be available. In those cases try doing this instead:
+> #### Note
+> 
+> sometimes `source` might not be available. In those cases try doing this instead:
 >
 >{% filename %}command-line{% endfilename %}
 >```
@@ -181,6 +199,8 @@ Successfully installed django-1.10.4
 <!--sec data-title="Windows" data-id="django_err_windows"
 data-collapse=true ces-->
 
+> #### Note
+> 
 > If you get an error when calling pip on Windows platform, please check if your project pathname contains spaces, accents or special characters (for example, `C:\Users\User Name\djangogirls`). If it does, please consider using another place without spaces, accents or special characters (suggestion: `C:\djangogirls`). Create a new virtualenv in the new directory, then delete the old one and try the above command again. (Moving the virtualenv directory won't work since virtualenv uses absolute paths.)
 
 <!--endsec-->
@@ -188,6 +208,8 @@ data-collapse=true ces-->
 <!--sec data-title="Windows 8 and Windows 10" data-id="django_err_windows8and10"
 data-collapse=true ces-->
 
+> #### Note
+> 
 > Your command line might freeze after when you try to install Django. If this happens, instead of the above command use:
 >
 >{% filename %}command-line{% endfilename %}
@@ -200,6 +222,8 @@ data-collapse=true ces-->
 <!--sec data-title="Linux" data-id="django_err_linux"
 data-collapse=true ces-->
 
+> #### Note
+> 
 > If you get an error when calling pip on Ubuntu 12.04 please run `python -m pip install -U --force-reinstall pip` to fix the pip installation in the virtualenv.
 
 <!--endsec-->

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -137,6 +137,8 @@ class Post(models.Model):
         return self.title
 ```
 
+> #### Note
+> 
 > Double-check that you use two underscore characters (`_`) on each side of `str`. This convention is used frequently in Python and sometimes we also call them "dunder" (short for "double-underscore").
 
 It looks scary, right? But don't worry – we will explain what these lines mean!

--- a/en/django_orm/README.md
+++ b/en/django_orm/README.md
@@ -136,7 +136,9 @@ Or maybe we want to see all the posts that contain the word 'title' in the `titl
 [<Post: Sample title>, <Post: 4th title of post>]
 ```
 
-> **Note** There are two underscore characters (`_`) between `title` and `contains`. Django's ORM uses this rule to separate field names ("title") and operations or filters ("contains"). If you use only one underscore, you'll get an error like "FieldError: Cannot resolve keyword title_contains".
+> #### Note
+> 
+> There are two underscore characters (`_`) between `title` and `contains`. Django's ORM uses this rule to separate field names ("title") and operations or filters ("contains"). If you use only one underscore, you'll get an error like "FieldError: Cannot resolve keyword title_contains".
 
 You can also get a list of all published posts. We do this by filtering all the posts that have `published_date` set in the past:
 

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -1,7 +1,9 @@
 # Your first Django project!
 
+> #### Info
+> 
 > Part of this chapter is based on tutorials by Geek Girls Carrots (https://github.com/ggcarrots/django-carrots).
-
+> 
 > Parts of this chapter are based on the [django-marcador
 tutorial](http://django-marcador.keimlink.de/) licensed under the Creative Commons
 Attribution-ShareAlike 4.0 International License. The django-marcador tutorial
@@ -13,7 +15,9 @@ The first step is to start a new Django project. Basically, this means that we'l
 
 The names of some files and directories are very important for Django. You should not rename the files that we are about to create. Moving them to a different place is also not a good idea. Django needs to maintain a certain structure to be able to find important things.
 
-> Remember to run everything in the virtualenv. If you don't see a prefix `(myvenv)` in your console, you need to activate your virtualenv. We explained how to do that in the __Django installation__ chapter in the __Working with virtualenv__ part. Typing `myvenv\Scripts\activate` on Windows or
+> #### Note
+> 
+> Remember to run everything in the virtualenv. If you don't see a prefix `(myvenv)` in your console, you need to activate your virtualenv. We explained how to do that in the [Django installation](../django_installation) chapter in the __Working with virtualenv__ part. Typing `myvenv\Scripts\activate` on Windows or
 `source myvenv/bin/activate` on Mac OS X or Linux will do this for you.
 
 <!--sec data-title="OS X or Linux" data-id="django_start_project_OSX_Linux" data-collapse=true ces-->
@@ -25,9 +29,15 @@ In your Mac OS X or Linux console, you should run the following command. **Don't
 (myvenv) ~/djangogirls$ django-admin startproject mysite .
 ```
 
+> #### Note
+> 
 > The period `.` is crucial because it tells the script to install Django in your current directory (for which the period `.` is a short-hand reference).
 
-> **Note** When typing the command above, remember that you only type the part which starts by `django-admin`.
+&nbsp;
+
+> #### Note
+> 
+> When typing the command above, remember that you only type the part which starts by `django-admin`.
 The `(myvenv) ~/djangogirls$` part shown here is just example of the prompt that will be inviting your input on your command line.
 
 <!--endsec-->
@@ -40,10 +50,16 @@ On Windows you should run the following command. **(Don't forget to add the peri
 ```
 (myvenv) C:\Users\Name\djangogirls> django-admin.py startproject mysite .
 ```
+> #### Note
+> 
 > The period `.` is crucial because it tells the script to install Django in your current directory (for which the period `.` is a short-hand reference).
 
-> **Note** When typing the command above, remember that you only type the part which starts by `django-admin.py`.
-The (myvenv) C:\Users\Name\djangogirls>` part shown here is just example of the prompt that will be inviting your input on your command line.
+&nbsp;
+
+> #### Note
+> 
+> When typing the command above, remember that you only type the part which starts by `django-admin.py`.
+The `(myvenv) C:\Users\Name\djangogirls>` part shown here is just example of the prompt that will be inviting your input on your command line.
 
 <!--endsec-->
 
@@ -58,7 +74,9 @@ djangogirls
         wsgi.py
         __init__.py
 ```
-> **Note**: in your directory structure, you will also see your `venv` directory that we created before.
+> #### Note
+> 
+> in your directory structure, you will also see your `venv` directory that we created before.
 
 `manage.py` is a script that helps with management of the site. With it we will be able (amongst other things) to start a web server on our computer without installing anything else.
 
@@ -98,7 +116,9 @@ match our hostname on PythonAnywhere once we deploy our application so we will c
 ALLOWED_HOSTS = ['127.0.0.1', '.pythonanywhere.com']
 ```
 
-> **Note**: If you're using a Chromebook, add this line at the bottom of your settings.py file:
+> #### Note
+> 
+> If you're using a Chromebook, add this line at the bottom of your settings.py file:
 > `MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'`
 
 ## Set up a database
@@ -186,7 +206,9 @@ Congratulations! You've just created your first website and run it using a web s
 
 While the web server is running, you won't see a new command-line prompt to enter additional commands. The terminal will accept new text but will not execute new commands. This is because the web server continuously runs in order to listen for incoming requests.
 
-> We reviewed how web servers work in the <b>How the Internet works</b> chapter.
+> #### Info
+> 
+> We reviewed how web servers work in the [How the Internet works](../how_the_internet_works/README.md) chapter.
 
 To type additional commands while the web server is running, open a new terminal window and activate your virtualenv. To stop the web server, switch back to the window in which it's running and press CTRL+C - Control and C buttons together (on Windows, you might have to press Ctrl+Break).
 

--- a/en/django_urls/README.md
+++ b/en/django_urls/README.md
@@ -123,4 +123,6 @@ If you try to visit http://127.0.0.1:8000/ now, then you'll find some sort of 'w
 
 Your console is showing an error, but don't worry – it's actually pretty useful: It's telling you that there is __no attribute 'post_list'__. That's the name of the *view* that Django is trying to find and use, but we haven't created it yet. At this stage your `/admin/` will also not work. No worries – we will get there.
 
+> #### Info
+> 
 > If you want to know more about Django URLconfs, look at the official documentation: https://docs.djangoproject.com/en/1.10/topics/http/urls/

--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -39,4 +39,6 @@ Another error! Read what's going on now:
 
 This shows that the server is running again, at least, but it still doesn't look right, does it? Don't worry, it's just an error page, nothing to be scared of! Just like the error messages in the console, these are actually pretty useful. You can read that the *TemplateDoesNotExist*. Let's fix this bug and create a template in the next chapter!
 
+> #### Info
+> 
 > Learn more about Django views by reading the official documentation: https://docs.djangoproject.com/en/1.10/topics/http/views/

--- a/en/how_the_internet_works/README.md
+++ b/en/how_the_internet_works/README.md
@@ -1,7 +1,9 @@
 # How the Internet works
 
-> For readers at home: this chapter is covered in the [How the Internet Works](https://www.youtube.com/watch?v=oM9yAA09wdc) video.
-
+> #### Info::For readers at home
+> 
+> This chapter is covered in the [How the Internet Works](https://www.youtube.com/watch?v=oM9yAA09wdc) video.
+> 
 > This chapter is inspired by the talk "How the Internet works" by Jessica McKellar (http://web.mit.edu/jesstess/www/).
 
 We bet you use the Internet every day. But do you actually know what happens when you type an address like https://djangogirls.org into your browser and press `enter`?

--- a/en/html/README.md
+++ b/en/html/README.md
@@ -30,6 +30,8 @@ And now create a `post_list.html` file (just leave it blank for now) inside the 
 
 See how your website looks now: http://127.0.0.1:8000/
 
+> #### Info
+> 
 > If you still have an error `TemplateDoesNotExist`, try to restart your server. Go into command line, stop the server by pressing Ctrl+C (Control and C buttons together) and start it again by running a `python manage.py runserver` command.
 
 ![Figure 11.1](images/step1.png)
@@ -168,7 +170,9 @@ Make sure you're in the `djangogirls` directory and let's tell `git` to include 
 $ git add --all .
 ```
 
-> __Note__ `--all` means that `git` will also recognize if you've deleted files (by default, it only recognizes new/modified files). Also remember (from chapter 3) that `.` means the current directory.
+> #### Note
+> 
+> `--all` means that `git` will also recognize if you've deleted files (by default, it only recognizes new/modified files). Also remember (from chapter 3) that `.` means the current directory.
 
 Before we upload all the files, let's check what `git` will be uploading (all the files that `git` will upload should now appear in green):
 
@@ -184,7 +188,9 @@ We're almost there, now it's time to tell it to save this change in its history.
 $ git commit -m "Changed the HTML for the site."
 ```
 
-> __Note__ Make sure you use double quotes around the commit message.
+> #### Note
+> 
+> Make sure you use double quotes around the commit message.
 
 Once we've done that, we upload (push) our changes up to GitHub:
 

--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -1,6 +1,8 @@
 # Introduction to the command-line interface
 
-> For readers at home: this chapter is covered in the [Your new friend: Command Line](https://www.youtube.com/watch?v=jvZLWhkzX-8) video.
+> #### Info::For readers at home
+> 
+> This chapter is covered in the [Your new friend: Command Line](https://www.youtube.com/watch?v=jvZLWhkzX-8) video.
 
 It's exciting, right?! You'll write your first line of code in just a few minutes! :)
 
@@ -8,7 +10,9 @@ __Let us introduce you to your first new friend: the command line!__
 
 The following steps will show you how to use the black window all hackers use. It might look a bit scary at first but really it's just a prompt waiting for commands from you.
 
-> **Note** Please note that throughout this book we use the terms 'directory' and 'folder' interchangeably but they are one and the same thing.
+> #### Note
+> 
+> Please note that throughout this book we use the terms 'directory' and 'folder' interchangeably but they are one and the same thing.
 
 ## What is the command line?
 
@@ -66,7 +70,9 @@ On Windows, it's a `>` sign, like this:
 
 Each command will be prepended by this sign and one space, but you don't have to type it. Your computer will do it for you. :)
 
-> Just a small note: in your case there may be something like `C:\Users\ola>` or `Olas-MacBook-Air:~ ola$` before the prompt sign, and this is 100% OK.
+> #### Note::Just a small note
+> 
+> In your case there may be something like `C:\Users\ola>` or `Olas-MacBook-Air:~ ola$` before the prompt sign, and this is 100% OK.
 
 The part up to and including the `$` or the `>` is called the *command line prompt*, or *prompt* for short. It prompts you to input something there.
 
@@ -105,6 +111,8 @@ olasitarska
 
 As you can see, the computer has just printed your username. Neat, huh? :)
 
+> #### Hint
+> 
 > Try to type each command; do not copy-paste. You'll remember more this way!
 
 ## Basics
@@ -124,7 +132,9 @@ $ pwd
 /Users/olasitarska
 ```
 
-> Note: 'pwd' stands for 'print working directory'.
+> #### Note
+> 
+> 'pwd' stands for 'print working directory'.
 
 <!--endsec-->
 
@@ -221,7 +231,9 @@ C:\Users\olasitarska\Desktop
 
 Here it is!
 
-> PRO tip: if you type `cd D` and then hit `tab` on your keyboard, the command line will automatically fill in the rest of the name so you can navigate faster. If there is more than one folder starting with "D", hit the `tab` button twice to get a list of options.
+> #### Hint::PRO tip
+> 
+> if you type `cd D` and then hit `tab` on your keyboard, the command line will automatically fill in the rest of the name so you can navigate faster. If there is more than one folder starting with "D", hit the `tab` button twice to get a list of options.
 
 ---
 
@@ -248,7 +260,9 @@ $ mkdir practice
 
 This little command will create a folder with the name `practice` on your desktop. You can check if it's there just by looking on your Desktop or by running a `ls` or `dir` command! Try it. :)
 
-> PRO tip: If you don't want to type the same commands over and over, try pressing the `up arrow` and `down arrow` on your keyboard to cycle through recently used commands.
+> #### Hint::PRO tip
+> 
+> If you don't want to type the same commands over and over, try pressing the `up arrow` and `down arrow` on your keyboard to cycle through recently used commands.
 
 ---
 
@@ -333,7 +347,9 @@ C:\Users\olasitarska\Desktop
 
 Now time to delete the `practice` directory:
 
-> __Attention__: Deleting files using `del`, `rmdir` or `rm` is irrecoverable, meaning _the deleted files will be gone forever_! So be very careful with this command.
+> #### Caution::Attention
+> 
+> Deleting files using `del`, `rmdir` or `rm` is irrecoverable, meaning _the deleted files will be gone forever_! So be very careful with this command.
 
 <!--sec data-title="OS X and Linux" data-id="OSX_Linux_rm" data-collapse=true ces-->
 

--- a/en/python_installation/README.md
+++ b/en/python_installation/README.md
@@ -8,9 +8,17 @@ Python originated in the late 1980s and its main goal is to be readable by human
 
 # Python installation
 
-> **Note** If you're using a Chromebook, skip this chapter and make sure you follow the [Chromebook Setup](../chromebook_setup/README.md) instructions.
+> #### Note
+> 
+> If you're using a Chromebook, skip this chapter and make sure you follow the [Chromebook Setup](../chromebook_setup/README.md) instructions.
 
-> **Note** If you already worked through the Installation steps, there's no need to do this again – you can skip straight ahead to the next chapter!
+&nbsp;
+
+> #### Note
+> 
+> If you already worked through the Installation steps, there's no need to do this again – you can skip straight ahead to the next chapter!
+
+&nbsp;
 
 {% include "/python_installation/instructions.md" %}
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -1,5 +1,7 @@
-> For readers at home: this chapter is covered in the [Installing Python & Code Editor](https://www.youtube.com/watch?v=pVTaqzKZCdA) video.
-
+> #### Info::For readers at home
+> 
+> this chapter is covered in the [Installing Python & Code Editor](https://www.youtube.com/watch?v=pVTaqzKZCdA) video.
+> 
 > This section is based on a tutorial by Geek Girls Carrots (https://github.com/ggcarrots/django-carrots)
 
 Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install Python 3.5, so if you have any earlier version, you will need to upgrade it.
@@ -30,7 +32,9 @@ If you install an older version of Python, the installation screen may look a bi
 <!--sec data-title="OS X" data-id="python_OSX"
 data-collapse=true ces-->
 
-> **Note** Before you install Python on OS X, you should ensure your Mac settings allow installing packages that aren't from the App Store. Go to System Preferences (it's in the Applications folder), click "Security & Privacy," and then the "General" tab. If your "Allow apps downloaded from:" is set to "Mac App Store," change it to "Mac App Store and identified developers."
+> #### Note
+> 
+> Before you install Python on OS X, you should ensure your Mac settings allow installing packages that aren't from the App Store. Go to System Preferences (it's in the Applications folder), click "Security & Privacy," and then the "General" tab. If your "Allow apps downloaded from:" is set to "Mac App Store," change it to "Mac App Store and identified developers."
 
 You need to go to the website https://www.python.org/downloads/release/python-351/ and download the Python installer:
 
@@ -112,7 +116,9 @@ $ python3 --version
 Python 3.5.1
 ```
 
-**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python 3.5.
+> #### NOTE
+> 
+> If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python 3.5.
 
 ----
 

--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -582,12 +582,19 @@ Now we need to save the file and give it a descriptive name. Let's call the file
 
 With the file saved, it's time to run it! Using the skills you've learned in the command line section, use the terminal to **change directories** to the desktop.
 
+<!--sec data-title="OS X" data-id="python_OSX"
+data-collapse=true ces-->
+
 On a Mac, the command will look something like this:
 
 {% filename %}command-line{% endfilename %}
 ```
 $ cd ~/Desktop
 ```
+<!--endsec-->
+
+<!--sec data-title="Linux" data-id="python_linux"
+data-collapse=true ces-->
 
 On Linux, it will be like this (the word "Desktop" might be translated to your local language):
 
@@ -596,12 +603,17 @@ On Linux, it will be like this (the word "Desktop" might be translated to your l
 $ cd ~/Desktop
 ```
 
+<!--endsec-->
+
+<!--sec data-title="Windows" data-id="python_windows" data-collapse=true ces-->
+
 And on Windows, it will be like this:
 
 {% filename %}command-line{% endfilename %}
 ```
 > cd %HomePath%\Desktop
 ```
+<!--endsec-->
 
 If you get stuck, just ask for help.
 

--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -1,12 +1,16 @@
 # Introduction to Python
 
+> #### Info
+> 
 > Part of this chapter is based on tutorials by Geek Girls Carrots (https://github.com/ggcarrots/django-carrots).
 
 Let's write some code!
 
 ## Python prompt
 
-> For readers at home: this part is covered in the [Python Basics: Integers, Strings, Lists, Variables and Errors](https://www.youtube.com/watch?v=MO63L4s-20U) video.
+> #### Info::For readers at home
+> 
+> This part is covered in the [Python Basics: Integers, Strings, Lists, Variables and Errors](https://www.youtube.com/watch?v=MO63L4s-20U) video.
 
 To start playing with Python, we need to open up a *command line* on your computer. You should already know how to do that – you learned it in the [Intro to Command Line](../intro_to_command_line/README.md) chapter.
 
@@ -155,7 +159,9 @@ It worked! We used the `str` function inside of the `len` function. `str()` conv
 - The `str` function converts things into __strings__
 - The `int` function converts things into __integers__
 
-> Important: we can convert numbers into text, but we can't necessarily convert text into numbers – what would `int('hello')` be anyway?
+> #### Info::Important
+> 
+> we can convert numbers into text, but we can't necessarily convert text into numbers – what would `int('hello')` be anyway?
 
 ## Variables
 
@@ -334,7 +340,9 @@ You can find a list of all available list methods in this chapter of the Python 
 
 ## Dictionaries
 
-> For readers at home: this part is covered in the [Python Basics: Dictionaries](https://www.youtube.com/watch?v=ZX1CVvZLE6c) video.
+> #### Info::For readers at home
+> 
+> This part is covered in the [Python Basics: Dictionaries](https://www.youtube.com/watch?v=ZX1CVvZLE6c) video.
 
 A dictionary is similar to a list, but you access values by looking up a key instead of a numeric index. A key can be any string or number. The syntax to define an empty dictionary is:
 
@@ -438,7 +446,9 @@ Excited for the next part? :)
 
 ## Compare things
 
-> For readers at home: this part is covered in the [Python Basics: Comparisons](https://www.youtube.com/watch?v=7bzxqIKYgf4) video.
+> #### Info::For readers at home
+> 
+> This part is covered in the [Python Basics: Comparisons](https://www.youtube.com/watch?v=7bzxqIKYgf4) video.
 
 A big part of programming involves comparing things. What's the easiest thing to compare? Numbers, of course. Let's see how that works:
 
@@ -546,7 +556,9 @@ Congrats! Booleans are one of the coolest features in programming, and you just 
 
 # Save it!
 
-> For readers at home: this part is covered in the [Python Basics: Saving files and "If" statement](https://www.youtube.com/watch?v=dOAg6QVAxyk) video.
+> #### Info::For readers at home
+> 
+> This part is covered in the [Python Basics: Saving files and "If" statement](https://www.youtube.com/watch?v=dOAg6QVAxyk) video.
 
 
 So far we've been writing all our python code in the interpreter, which limits us to entering one line of code at a time. Normal programs are saved in files and executed by our programming language __interpreter__ or __compiler__. So far we've been running our programs one line at a time in the Python __interpreter__. We're going to need more than one line of code for the next few tasks, so we'll quickly need to:
@@ -577,7 +589,9 @@ Obviously, you're a pretty seasoned Python developer now, so feel free to write 
 
 Now we need to save the file and give it a descriptive name. Let's call the file **python_intro.py** and save it to your desktop. We can name the file anything we want, but the important part here is to make sure the file ends in __.py__. The __.py__ extension tells our operating system that this is a **Python executable file** and Python can run it.
 
-> **Note** You should notice one of the coolest thing about code editors: colors! In the Python console, everything was the same color; now you should see that the `print` function is a different color from the string. This is called "syntax highlighting", and it's a really useful feature when coding. The color of things will give you hints, such as unclosed strings or a typo in a keyword name (like the `def` in a function, which we'll see below). This is one of the reasons we use a code editor. :)
+> #### Note
+> 
+> You should notice one of the coolest thing about code editors: colors! In the Python console, everything was the same color; now you should see that the `print` function is a different color from the string. This is called "syntax highlighting", and it's a really useful feature when coding. The color of things will give you hints, such as unclosed strings or a typo in a keyword name (like the `def` in a function, which we'll see below). This is one of the reasons we use a code editor. :)
 
 
 With the file saved, it's time to run it! Using the skills you've learned in the command line section, use the terminal to **change directories** to the desktop.
@@ -675,7 +689,9 @@ $ python3 python_intro.py
 It works!
 ```
 
-Note: Remember that on Windows, 'python3' is not recognized as a command. From now on, replace 'python3' with 'python' to execute the file.
+> #### Note
+> 
+> Remember that on Windows, 'python3' is not recognized as a command. From now on, replace 'python3' with 'python' to execute the file.
 
 ### What if a condition isn't True?
 
@@ -778,7 +794,9 @@ Time for the last part of this chapter!
 
 ## Your own functions!
 
-> For readers at home: this part is covered in the [Python Basics: Functions](https://www.youtube.com/watch?v=5owr-6suOl0) video.
+> #### Info::For readers at home
+> 
+> This part is covered in the [Python Basics: Functions](https://www.youtube.com/watch?v=5owr-6suOl0) video.
 
 Remember functions like `len()` that you can execute in Python? Well, good news – you will learn how to write your own functions now!
 
@@ -907,7 +925,9 @@ Congratulations! You just learned how to write functions! :)
 
 ## Loops
 
-> For readers at home: this part is covered in the [Python Basics: For Loop](https://www.youtube.com/watch?v=aEA6Rc86HF0) video.
+> #### Info::For readers at home
+> 
+> This part is covered in the [Python Basics: For Loop](https://www.youtube.com/watch?v=aEA6Rc86HF0) video.
 
 This is the last part already. That was quick, right? :)
 

--- a/en/template_extending/README.md
+++ b/en/template_extending/README.md
@@ -140,4 +140,6 @@ Only one thing left. We need to connect these two templates together.  This is w
 
 That's it! Check if your website is still working properly. :)
 
+> #### Note
+> 
 > If you get the error `TemplateDoesNotExist`, that means that there is no `blog/base.html` file and you have `runserver` running in the console. Try to stop it (by pressing Ctrl+C – the Control and C keys together) and restart it by running a `python manage.py runserver` command.


### PR DESCRIPTION
It appears the `richquotes` plugin wasn't compatible with GitBook 3.x.x and the blockquotes weren't being.. um.. richified. I've replaced the plugin with one called `callouts` which is a more up to date fork, and I've applied the appropriate syntax to all the quote boxes in the **en** version. 

If this seems like a good idea, I'll update the other languages too.